### PR TITLE
Switch base to MCR-hosted image

### DIFF
--- a/.base/Dockerfile
+++ b/.base/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1.403-sdk
+FROM mcr.microsoft.com/dotnet/sdk:2.1
 
 RUN apt update -y \
  && apt install -y apt-transport-https dirmngr \


### PR DESCRIPTION
See: https://web.archive.org/web/20211103000735/https://devblogs.microsoft.com/dotnet/net-core-2-1-container-images-will-be-deleted-from-docker-hub/